### PR TITLE
hotfix/the set event and tags as array

### DIFF
--- a/src/Helpers/BuildUri.php
+++ b/src/Helpers/BuildUri.php
@@ -17,7 +17,7 @@ class BuildUri
 
         foreach ($params as $key => $value) {
             if (is_array($value)) {
-                $value = implode(',', $value);
+                $value = implode("&$key=", $value);
             }
 
             $paramsArray[] = $key.'='.$value;

--- a/src/Helpers/Builder/ActivityAnalyticsParams.php
+++ b/src/Helpers/Builder/ActivityAnalyticsParams.php
@@ -88,8 +88,8 @@ class ActivityAnalyticsParams
             'date_from' => $this->getDateFrom(),
             'date_to' => $this->getDateTo(),
             'group_by' => $this->getGroupBy(),
-            'tags' => $this->getTags(),
-            'event' => $this->getEvent(),
+            'tags[]' => $this->getTags(),
+            'event[]' => $this->getEvent(),
         ];
     }
 }


### PR DESCRIPTION
make the set events and the set tags readable as arrays in the package, instead of reading it as non-array variable, which caused a syntax error while using the package in a Laravel project.